### PR TITLE
Support CommandLineTool, tested

### DIFF
--- a/cwl_airflow_parser/cwldag.py
+++ b/cwl_airflow_parser/cwldag.py
@@ -96,7 +96,7 @@ class CWLDAG(DAG):
         return cwl_data
 
     def create(self):
-        if self.cwlwf["class"] == "CommandLineTool":
+        if self.cwlwf["class"] in ["CommandLineTool", "ExpressionTool"]:
             cwl_task = CWLStepOperator(task_id=self.dag_id,
                                        dag=self,
                                        ui_color='#5C6BC0')

--- a/cwl_airflow_parser/cwldag.py
+++ b/cwl_airflow_parser/cwldag.py
@@ -160,6 +160,11 @@ class CWLDAG(DAG):
                     t.reader_task_id = self.top_task.task_id
 
     def get_output_list(self):
-        outputs = {out_val["outputSource"]: out_id for out_id, out_val in self.cwlwf["outputs"].items() if "outputSource" in out_val}
+        outputs = {}
+        for out_id, out_val in self.cwlwf["outputs"].items():
+            if "outputSource" in out_val:
+                outputs[out_val["outputSource"]] = out_id
+            else:
+                outputs[out_id] = out_id
         _logger.debug("{0} get_output_list: \n{1}".format(self.dag_id, outputs))
         return outputs

--- a/cwl_airflow_parser/cwlstepoperator.py
+++ b/cwl_airflow_parser/cwlstepoperator.py
@@ -123,10 +123,9 @@ class CWLStepOperator(BaseOperator):
             jobobj_id = shortname(inp["id"]).split("/")[-1]
             source_ids = []
             promises_outputs = []
+            source_field = inp["source"] if it_is_workflow else inp.get("id")
             try:
-                source_ids = [shortname(source) for source in inp["source"]] \
-                    if isinstance(inp["source"], list) else [shortname(inp["source"])]
-
+                source_ids = [shortname(s) for s in source_field] if isinstance(source_field, list) else [shortname(source_field)]
                 promises_outputs = [promises[source_id] for source_id in source_ids if source_id in promises]
             except:
                 _logger.warning("{0}: Couldn't find source field in step input: {1}"

--- a/cwl_airflow_parser/cwlstepoperator.py
+++ b/cwl_airflow_parser/cwlstepoperator.py
@@ -123,8 +123,8 @@ class CWLStepOperator(BaseOperator):
             jobobj_id = shortname(inp["id"]).split("/")[-1]
             source_ids = []
             promises_outputs = []
-            source_field = inp["source"] if it_is_workflow else inp.get("id")
             try:
+                source_field = inp["source"] if it_is_workflow else inp.get("id")
                 source_ids = [shortname(s) for s in source_field] if isinstance(source_field, list) else [shortname(source_field)]
                 promises_outputs = [promises[source_id] for source_id in source_ids if source_id in promises]
             except:

--- a/cwl_airflow_parser/cwlutils.py
+++ b/cwl_airflow_parser/cwlutils.py
@@ -95,7 +95,9 @@ def load_cwl(cwl_file, default_args):
     loading_context = LoadingContext(default_args)
     loading_context.construct_tool_object = default_make_tool
     loading_context.resolver = tool_resolver
-    return load.load_tool(cwl_file, loading_context)
+    tool = load.load_tool(cwl_file, loading_context)
+    it_is_workflow = tool.tool["class"] == "Workflow"
+    return tool, it_is_workflow
 
 
 def post_status_info(context):

--- a/cwl_airflow_parser/operators/cwljobdispatcher.py
+++ b/cwl_airflow_parser/operators/cwljobdispatcher.py
@@ -66,7 +66,7 @@ class CWLJobDispatcher(BaseOperator):
 
     def cwl_dispatch(self, json):
         try:
-            cwlwf = load_cwl(self.dag.default_args["cwl_workflow"], self.dag.default_args)
+            cwlwf, it_is_workflow = load_cwl(self.dag.default_args["cwl_workflow"], self.dag.default_args)
             cwl_context = {
                 "outdir": mkdtemp(
                     prefix=os.path.abspath(os.path.join(self.tmp_folder, 'dag_tmp_')))

--- a/cwl_airflow_parser/utils/cwls/sleep_cwl_tool.cwl
+++ b/cwl_airflow_parser/utils/cwls/sleep_cwl_tool.cwl
@@ -1,0 +1,27 @@
+class: CommandLineTool
+cwlVersion: v1.0
+
+
+hints:
+  - class: DockerRequirement
+    dockerPull: ubuntu:xenial
+
+
+inputs:
+
+  delay:
+    type: int?
+    inputBinding:
+      position: 1
+    default: 5
+
+
+outputs:
+
+  empty_file:
+    type: File?
+    outputBinding:
+      glob: "*"
+
+
+baseCommand: [sleep]

--- a/cwl_airflow_parser/utils/cwls/sleep_cwl_workflow.cwl
+++ b/cwl_airflow_parser/utils/cwls/sleep_cwl_workflow.cwl
@@ -5,7 +5,7 @@ cwlVersion: v1.0
 inputs:
   delay:
     type: int
-    default: 600
+    default: 5
 
 
 outputs:

--- a/cwl_airflow_parser/utils/dags/sleep_cwl_tool.py
+++ b/cwl_airflow_parser/utils/dags/sleep_cwl_tool.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+import os
+from cwl_airflow_parser import CWLDAG, CWLJobDispatcher, CWLJobGatherer
+
+DIR = os.path.join(os.path.dirname(os.path.abspath(os.path.join(__file__, "../"))), "cwls")
+
+def cwl_workflow(workflow_file):
+    dag = CWLDAG(cwl_workflow=workflow_file)
+    dag.create()
+    dag.add(CWLJobDispatcher(dag=dag), to='top')
+    dag.add(CWLJobGatherer(dag=dag), to='bottom')
+    return dag
+
+dag = cwl_workflow(os.path.join(DIR, "sleep_cwl_tool.cwl"))

--- a/cwl_airflow_parser/utils/dags/sleep_cwl_workflow.py
+++ b/cwl_airflow_parser/utils/dags/sleep_cwl_workflow.py
@@ -11,4 +11,4 @@ def cwl_workflow(workflow_file):
     dag.add(CWLJobGatherer(dag=dag), to='bottom')
     return dag
 
-dag = cwl_workflow(os.path.join(DIR, "sleep_for_an_hour_cwl_docker.cwl"))
+dag = cwl_workflow(os.path.join(DIR, "sleep_cwl_workflow.cwl"))


### PR DESCRIPTION
Support `CommandLineTool` & `ExpressionTool` (DAG includes only one step)
Tested with [conformance_tests.yaml](https://github.com/Barski-lab/workflows/blob/3e2ad9c049ea96584c365559c687205e3b642146/tests/conformance_tests.yaml)
190 out of 195 - success
5 tests failed:
- files-to-folder x 2
   cwltool related bug when returning Directory
   ```
   AttributeError: 'posix.DirEntry' object has no attribute 'startswith'
   ```
- heatmap-prepare x 3 (scatter is not supported)